### PR TITLE
bugfix: do not count empty strings as words

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,12 @@ import './App.css';
 import { Typography } from '@material-ui/core';
 import TextComponent from './TextComponent';
 
-
 function App() {
   return (
     <div className="App">
       <Typography variant="h2">Type your text to start counting words</Typography>
       <TextComponent></TextComponent>
     </div>
-    
   );
 }
 

--- a/src/TextComponent.js
+++ b/src/TextComponent.js
@@ -5,17 +5,16 @@ export default function TextComponent(){
   const [wordCount, setWordCount] = React.useState(0);
 
   const handleTextChange = (event) => {
-    const res= event.target.value.split(' ');
-    setWordCount(res.length);
+    const res = event.target.value.split(' ');
+    setWordCount(res.filter((str) => str !== '').length);
   }
   return (
     <div>
       <TextField
         id="outlined-multiline-static"
-        label=""
+        label="Your text"
         multiline
         rows={4}
-        defaultValue="Type your text here..."
         variant="outlined"
         onChange={handleTextChange}
       />


### PR DESCRIPTION
Add filter on splitted array of string to avoid counting empty string as a word